### PR TITLE
fix: set appium tags

### DIFF
--- a/lib/src/components/text_field_label.dart
+++ b/lib/src/components/text_field_label.dart
@@ -4,12 +4,12 @@ import 'package:flutter/material.dart';
 /// If semantic label is not provided, it will use the text as semantic label
 class TextFieldLabel extends StatelessWidget {
   final String text;
-  final String? semanticLabel;
+  final String? semanticsLabel;
 
   const TextFieldLabel({
     super.key,
     required this.text,
-    this.semanticLabel,
+    this.semanticsLabel,
   });
 
   @override
@@ -19,7 +19,7 @@ class TextFieldLabel extends StatelessWidget {
             WidgetSpan(
               child: Text(
                 text,
-                semanticsLabel: semanticLabel ?? text,
+                semanticsLabel: semanticsLabel ?? text,
               ),
             ),
           ],

--- a/lib/src/components/text_field_label.dart
+++ b/lib/src/components/text_field_label.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+/// Text field label with semantic label for accessibility
+/// If semantic label is not provided, it will use the text as semantic label
+class TextFieldLabel extends StatelessWidget {
+  final String text;
+  final String? semanticLabel;
+
+  const TextFieldLabel({
+    super.key,
+    required this.text,
+    this.semanticLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) => Text.rich(
+        TextSpan(
+          children: <InlineSpan>[
+            WidgetSpan(
+              child: Text(
+                text,
+                semanticsLabel: semanticLabel ?? text,
+              ),
+            ),
+          ],
+        ),
+      );
+}

--- a/lib/src/screens/attributes.dart
+++ b/lib/src/screens/attributes.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../components/container.dart';
 import '../components/scroll_view.dart';
+import '../components/text_field_label.dart';
 import '../theme/sizes.dart';
 import '../utils/extensions.dart';
 
@@ -57,6 +58,17 @@ class AttributesScreen extends StatefulWidget {
     }
   }
 
+  String get sendAttributeButtonSemanticsLabel {
+    switch (_attributeType) {
+      case _attributeTypeDevice:
+        return 'Set Device Attribute Button';
+      case _attributeTypeProfile:
+        return 'Set Profile Attribute Button';
+      default:
+        throw ArgumentError('Invalid attribute type specified');
+    }
+  }
+
   @override
   State<AttributesScreen> createState() => _AttributesScreenState();
 }
@@ -106,7 +118,10 @@ class _AttributesScreenState extends State<AttributesScreen> {
                   decoration: const InputDecoration(
                     border: OutlineInputBorder(),
                     isDense: true,
-                    labelText: 'Attribute Name',
+                    label: TextFieldLabel(
+                      text: 'Attribute Name',
+                      semanticsLabel: 'Attribute Name Input',
+                    ),
                   ),
                   keyboardType: TextInputType.text,
                   textCapitalization: TextCapitalization.none,
@@ -118,7 +133,10 @@ class _AttributesScreenState extends State<AttributesScreen> {
                   decoration: const InputDecoration(
                     border: OutlineInputBorder(),
                     isDense: true,
-                    labelText: 'Attribute Value',
+                    label: TextFieldLabel(
+                      text: 'Attribute Value',
+                      semanticsLabel: 'Attribute Value Input',
+                    ),
                   ),
                   keyboardType: TextInputType.text,
                   textCapitalization: TextCapitalization.none,
@@ -150,6 +168,7 @@ class _AttributesScreenState extends State<AttributesScreen> {
                   },
                   child: Text(
                     widget.sendAttributeButtonText,
+                    semanticsLabel: widget.sendAttributeButtonSemanticsLabel,
                   ),
                 ),
                 const Spacer(),

--- a/lib/src/screens/dashboard.dart
+++ b/lib/src/screens/dashboard.dart
@@ -101,7 +101,10 @@ class _DashboardScreenState extends State<DashboardScreen> {
       appBar: AppBar(
         actions: <Widget>[
           IconButton(
-            icon: const Icon(Icons.settings),
+            icon: Semantics(
+              label: 'Settings',
+              child: const Icon(Icons.settings),
+            ),
             tooltip: 'Open SDK Configurations',
             onPressed: () {
               context.push(Screen.settings.location);

--- a/lib/src/screens/dashboard.dart
+++ b/lib/src/screens/dashboard.dart
@@ -234,6 +234,7 @@ class _ActionList extends StatelessWidget {
                     },
                     child: Text(
                       item.buildText(),
+                      semanticsLabel: item.semanticsLabel(),
                     ),
                   ),
                 ))
@@ -268,6 +269,23 @@ extension _ActionNames on _ActionItem {
         return 'Show Push Prompt';
       case _ActionItem.signOut:
         return 'Log Out';
+    }
+  }
+
+  String semanticsLabel() {
+    switch (this) {
+      case _ActionItem.randomEvent:
+        return 'Random Event Button';
+      case _ActionItem.customEvent:
+        return 'Custom Event Button';
+      case _ActionItem.deviceAttributes:
+        return 'Device Attribute Button';
+      case _ActionItem.profileAttributes:
+        return 'Profile Attribute Button';
+      case _ActionItem.showPushPrompt:
+        return 'Show Push Prompt Button';
+      case _ActionItem.signOut:
+        return 'Log Out Button';
     }
   }
 

--- a/lib/src/screens/dashboard.dart
+++ b/lib/src/screens/dashboard.dart
@@ -120,6 +120,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
             Center(
               child: Text(
                 _email ?? '',
+                semanticsLabel: 'Email ID Text',
                 style: Theme.of(context).textTheme.titleSmall,
               ),
             ),

--- a/lib/src/screens/events.dart
+++ b/lib/src/screens/events.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../components/container.dart';
 import '../components/scroll_view.dart';
+import '../components/text_field_label.dart';
 import '../theme/sizes.dart';
 import '../utils/extensions.dart';
 
@@ -58,7 +59,10 @@ class _CustomEventScreenState extends State<CustomEventScreen> {
                   decoration: const InputDecoration(
                     border: OutlineInputBorder(),
                     isDense: true,
-                    labelText: 'Event Name',
+                    label: TextFieldLabel(
+                      text: 'Event Name',
+                      semanticsLabel: 'Event Name Input',
+                    ),
                   ),
                   keyboardType: TextInputType.text,
                   textCapitalization: TextCapitalization.none,
@@ -70,7 +74,10 @@ class _CustomEventScreenState extends State<CustomEventScreen> {
                   decoration: const InputDecoration(
                     border: OutlineInputBorder(),
                     isDense: true,
-                    labelText: 'Property Name',
+                    label: TextFieldLabel(
+                      text: 'Property Name',
+                      semanticsLabel: 'Property Name Input',
+                    ),
                   ),
                   keyboardType: TextInputType.text,
                   textCapitalization: TextCapitalization.none,
@@ -82,7 +89,10 @@ class _CustomEventScreenState extends State<CustomEventScreen> {
                   decoration: const InputDecoration(
                     border: OutlineInputBorder(),
                     isDense: true,
-                    labelText: 'Property Value',
+                    label: TextFieldLabel(
+                      text: 'Property Value',
+                      semanticsLabel: 'Property Value Input',
+                    ),
                   ),
                   keyboardType: TextInputType.text,
                   textCapitalization: TextCapitalization.none,
@@ -108,6 +118,7 @@ class _CustomEventScreenState extends State<CustomEventScreen> {
                   },
                   child: const Text(
                     'Send Event',
+                    semanticsLabel: 'Send Event Button',
                   ),
                 ),
                 const Spacer(),

--- a/lib/src/screens/login.dart
+++ b/lib/src/screens/login.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../components/container.dart';
 import '../components/scroll_view.dart';
+import '../components/text_field_label.dart';
 import '../customer_io.dart';
 import '../data/screen.dart';
 import '../data/user.dart';
@@ -47,8 +48,11 @@ class _LoginScreenState extends State<LoginScreen> {
       appBar: AppBar(
         actions: <Widget>[
           IconButton(
-            icon: const Icon(Icons.settings),
-            tooltip: 'Open SDK Configurations',
+            icon: Semantics(
+              label: 'Settings',
+              child: const Icon(Icons.settings),
+            ),
+            tooltip: 'Open SDK Settings',
             onPressed: () {
               context.push(Screen.settings.location);
             },
@@ -84,7 +88,10 @@ class _LoginScreenState extends State<LoginScreen> {
                       decoration: const InputDecoration(
                         border: OutlineInputBorder(),
                         isDense: true,
-                        labelText: 'First Name',
+                        label: TextFieldLabel(
+                          text: 'First Name',
+                          semanticLabel: 'First Name Input',
+                        ),
                       ),
                       keyboardType: TextInputType.name,
                       textCapitalization: TextCapitalization.words,
@@ -97,7 +104,10 @@ class _LoginScreenState extends State<LoginScreen> {
                         decoration: const InputDecoration(
                           border: OutlineInputBorder(),
                           isDense: true,
-                          labelText: 'Email',
+                          label: TextFieldLabel(
+                            text: 'Email',
+                            semanticLabel: 'Email Input',
+                          ),
                         ),
                         keyboardType: TextInputType.emailAddress,
                         textInputAction: TextInputAction.done,
@@ -126,6 +136,7 @@ class _LoginScreenState extends State<LoginScreen> {
                         },
                         child: Text(
                           'Login'.toUpperCase(),
+                          semanticsLabel: 'Login Button',
                         ),
                       ),
                     ),
@@ -145,6 +156,7 @@ class _LoginScreenState extends State<LoginScreen> {
                         },
                         child: const Text(
                           'Generate Random Login',
+                          semanticsLabel: 'Random Login Button',
                         ),
                       ),
                     ),

--- a/lib/src/screens/login.dart
+++ b/lib/src/screens/login.dart
@@ -90,7 +90,7 @@ class _LoginScreenState extends State<LoginScreen> {
                         isDense: true,
                         label: TextFieldLabel(
                           text: 'First Name',
-                          semanticLabel: 'First Name Input',
+                          semanticsLabel: 'First Name Input',
                         ),
                       ),
                       keyboardType: TextInputType.name,
@@ -106,7 +106,7 @@ class _LoginScreenState extends State<LoginScreen> {
                           isDense: true,
                           label: TextFieldLabel(
                             text: 'Email',
-                            semanticLabel: 'Email Input',
+                            semanticsLabel: 'Email Input',
                           ),
                         ),
                         keyboardType: TextInputType.emailAddress,

--- a/lib/src/screens/login.dart
+++ b/lib/src/screens/login.dart
@@ -97,67 +97,59 @@ class _LoginScreenState extends State<LoginScreen> {
                       textCapitalization: TextCapitalization.words,
                       textInputAction: TextInputAction.next,
                     ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 16.0),
-                      child: TextFormField(
-                        controller: _emailController,
-                        decoration: const InputDecoration(
-                          border: OutlineInputBorder(),
-                          isDense: true,
-                          label: TextFieldLabel(
-                            text: 'Email',
-                            semanticsLabel: 'Email Input',
-                          ),
-                        ),
-                        keyboardType: TextInputType.emailAddress,
-                        textInputAction: TextInputAction.done,
-                        validator: (value) =>
-                            EmailValidator.validate(value ?? '')
-                                ? null
-                                : 'Please enter valid email',
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 48.0),
-                      child: FilledButton(
-                        style: FilledButton.styleFrom(
-                          minimumSize: sizes.buttonDefault(),
-                        ),
-                        onPressed: () async {
-                          _autoValidateMode =
-                              AutovalidateMode.onUserInteraction;
-                          if (_formKey.currentState!.validate()) {
-                            widget.onLogin(User(
-                              displayName: _fullNameController.value.text,
-                              email: _emailController.value.text,
-                              isGuest: false,
-                            ));
-                          }
-                        },
-                        child: Text(
-                          'Login'.toUpperCase(),
-                          semanticsLabel: 'Login Button',
+                    const SizedBox(height: 16.0),
+                    TextFormField(
+                      controller: _emailController,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                        label: TextFieldLabel(
+                          text: 'Email',
+                          semanticsLabel: 'Email Input',
                         ),
                       ),
+                      keyboardType: TextInputType.emailAddress,
+                      textInputAction: TextInputAction.done,
+                      validator: (value) => EmailValidator.validate(value ?? '')
+                          ? null
+                          : 'Please enter valid email',
                     ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 16.0),
-                      child: TextButton(
-                        style: FilledButton.styleFrom(
-                          minimumSize: sizes.buttonDefault(),
-                        ),
-                        onPressed: () async {
-                          final randomValues = RandomValues();
+                    const SizedBox(height: 48.0),
+                    FilledButton(
+                      style: FilledButton.styleFrom(
+                        minimumSize: sizes.buttonDefault(),
+                      ),
+                      onPressed: () async {
+                        _autoValidateMode = AutovalidateMode.onUserInteraction;
+                        if (_formKey.currentState!.validate()) {
                           widget.onLogin(User(
-                            displayName: '',
-                            email: randomValues.getEmail(),
-                            isGuest: true,
+                            displayName: _fullNameController.value.text,
+                            email: _emailController.value.text,
+                            isGuest: false,
                           ));
-                        },
-                        child: const Text(
-                          'Generate Random Login',
-                          semanticsLabel: 'Random Login Button',
-                        ),
+                        }
+                      },
+                      child: Text(
+                        'Login'.toUpperCase(),
+                        semanticsLabel: 'Login Button',
+                      ),
+                    ),
+                    const SizedBox(height: 16.0),
+                    TextButton(
+                      style: FilledButton.styleFrom(
+                        minimumSize: sizes.buttonDefault(),
+                      ),
+                      onPressed: () async {
+                        final randomValues = RandomValues();
+                        widget.onLogin(User(
+                          displayName: '',
+                          email: randomValues.getEmail(),
+                          isGuest: true,
+                        ));
+                      },
+                      child: const Text(
+                        'Generate Random Login',
+                        semanticsLabel: 'Random Login Button',
                       ),
                     ),
                   ],

--- a/lib/src/screens/settings.dart
+++ b/lib/src/screens/settings.dart
@@ -1,4 +1,3 @@
-import 'package:amiapp_flutter/src/data/screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
@@ -7,6 +6,7 @@ import '../auth.dart';
 import '../components/container.dart';
 import '../customer_io.dart';
 import '../data/config.dart';
+import '../data/screen.dart';
 import '../theme/sizes.dart';
 import '../utils/extensions.dart';
 import '../widgets/app_footer.dart';

--- a/lib/src/screens/settings.dart
+++ b/lib/src/screens/settings.dart
@@ -160,6 +160,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         children: [
                           TextSettingsFormField(
                             labelText: 'Device Token',
+                            semanticsLabel: 'Device Token Input',
                             valueController: _deviceTokenValueController,
                             readOnly: true,
                             suffixIcon: IconButton(
@@ -177,6 +178,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           const SizedBox(height: 16),
                           TextSettingsFormField(
                             labelText: 'CIO Track URL',
+                            semanticsLabel: 'Track URL Input',
                             valueController: _trackingURLValueController,
                             validator: (value) => value?.isValidUrl() != false
                                 ? null
@@ -185,6 +187,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           const SizedBox(height: 32),
                           TextSettingsFormField(
                             labelText: 'Site Id',
+                            semanticsLabel: 'Site ID Input',
                             valueController: _siteIDValueController,
                             validator: (value) =>
                                 value?.trim().isNotEmpty == true
@@ -194,6 +197,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           const SizedBox(height: 16),
                           TextSettingsFormField(
                             labelText: 'API Key',
+                            semanticsLabel: 'API Key Input',
                             valueController: _apiKeyValueController,
                             validator: (value) =>
                                 value?.trim().isNotEmpty == true
@@ -203,6 +207,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           const SizedBox(height: 32),
                           TextSettingsFormField(
                             labelText: 'backgroundQueueSecondsDelay',
+                            semanticsLabel: 'BQ Seconds Delay Input',
                             valueController: _bqSecondsDelayValueController,
                             keyboardType: const TextInputType.numberWithOptions(
                                 decimal: true),
@@ -225,6 +230,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           const SizedBox(height: 16),
                           TextSettingsFormField(
                             labelText: 'backgroundQueueMinNumberOfTasks',
+                            semanticsLabel: 'BQ Min Number of Tasks Input',
                             valueController: _bqMinNumberOfTasksValueController,
                             keyboardType: TextInputType.number,
                             validator: (value) {
@@ -249,18 +255,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           ),
                           SwitchSettingsFormField(
                             labelText: 'Track Screens',
+                            semanticsLabel: 'Track Screens Toggle',
                             value: _featureTrackScreens,
                             updateState: ((value) =>
                                 setState(() => _featureTrackScreens = value)),
                           ),
                           SwitchSettingsFormField(
                             labelText: 'Track Device Attributes',
+                            semanticsLabel: 'Track Device Attributes Toggle',
                             value: _featureTrackDeviceAttributes,
                             updateState: ((value) => setState(
                                 () => _featureTrackDeviceAttributes = value)),
                           ),
                           SwitchSettingsFormField(
                             labelText: 'Debug Mode',
+                            semanticsLabel: 'Debug Mode Toggle',
                             value: _featureDebugMode,
                             updateState: ((value) =>
                                 setState(() => _featureDebugMode = value)),
@@ -281,6 +290,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 onPressed: () => _saveSettings(),
                 child: Text(
                   'Save'.toUpperCase(),
+                  semanticsLabel: 'Save Settings Button',
                 ),
               ),
             ),
@@ -291,6 +301,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               onPressed: () => _restoreDefaultSettings(),
               child: const Text(
                 'Restore Defaults',
+                semanticsLabel: 'Restore Default Settings Button',
               ),
             ),
             const SizedBox(height: 8),

--- a/lib/src/widgets/settings_form_field.dart
+++ b/lib/src/widgets/settings_form_field.dart
@@ -1,5 +1,6 @@
-import 'package:amiapp_flutter/src/components/text_field_label.dart';
 import 'package:flutter/material.dart';
+
+import '../components/text_field_label.dart';
 
 class TextSettingsFormField extends StatelessWidget {
   const TextSettingsFormField({

--- a/lib/src/widgets/settings_form_field.dart
+++ b/lib/src/widgets/settings_form_field.dart
@@ -1,9 +1,11 @@
+import 'package:amiapp_flutter/src/components/text_field_label.dart';
 import 'package:flutter/material.dart';
 
 class TextSettingsFormField extends StatelessWidget {
   const TextSettingsFormField({
     super.key,
     required this.labelText,
+    required this.semanticsLabel,
     required this.valueController,
     this.hintText,
     this.readOnly = false,
@@ -15,6 +17,7 @@ class TextSettingsFormField extends StatelessWidget {
   });
 
   final String labelText;
+  final String semanticsLabel;
   final String? hintText;
   final bool readOnly;
   final TextInputType keyboardType;
@@ -53,7 +56,10 @@ class TextSettingsFormField extends StatelessWidget {
               readOnly: readOnly,
               decoration: InputDecoration(
                 border: const OutlineInputBorder(),
-                labelText: labelText,
+                label: TextFieldLabel(
+                  text: labelText,
+                  semanticLabel: semanticsLabel,
+                ),
                 hintText: hintText,
                 isDense: true,
                 floatingLabelBehavior: floatingLabelBehavior,
@@ -74,12 +80,14 @@ class SwitchSettingsFormField extends StatelessWidget {
   const SwitchSettingsFormField({
     super.key,
     required this.labelText,
+    required this.semanticsLabel,
     required this.value,
     required this.updateState,
     this.enabled = true,
   });
 
   final String labelText;
+  final String semanticsLabel;
   final bool value;
   final void Function(bool) updateState;
   final bool enabled;
@@ -97,9 +105,12 @@ class SwitchSettingsFormField extends StatelessWidget {
               style: Theme.of(context).textTheme.bodyMedium,
             ),
           ),
-          Switch(
-            value: value,
-            onChanged: (bool value) => updateState(value),
+          Semantics(
+            label: semanticsLabel,
+            child: Switch(
+              value: value,
+              onChanged: (bool value) => updateState(value),
+            ),
           ),
         ],
       ),

--- a/lib/src/widgets/settings_form_field.dart
+++ b/lib/src/widgets/settings_form_field.dart
@@ -58,7 +58,7 @@ class TextSettingsFormField extends StatelessWidget {
                 border: const OutlineInputBorder(),
                 label: TextFieldLabel(
                   text: labelText,
-                  semanticLabel: semanticsLabel,
+                  semanticsLabel: semanticsLabel,
                 ),
                 hintText: hintText,
                 isDense: true,


### PR DESCRIPTION
part of: https://github.com/customerio/issues/issues/8958

### Changes

- Set content description for widgets so they can be located using `content-desc` by Appium
- Setting content description is apparently not allowed for input fields in Flutter, I added hint for input text fields so they can be located using `hint` by Appium
- Removed unnecessary nested padding from login screen